### PR TITLE
Adds prop-types package for react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "jasmine-reporters": "^2.1.1",
     "jest-cli": "^20.0.1",
     "mocha": "^3.3.0",
+    "prop-types": "^15.5.10",
     "react": "^15.5.4",
     "react-addons-test-utils": "^15.5.1",
     "react-dom": "^15.5.4",

--- a/src/Backdrop.js
+++ b/src/Backdrop.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View, StyleSheet, TouchableWithoutFeedback, Animated } from 'react-native';
 import { OPEN_ANIM_DURATION, CLOSE_ANIM_DURATION } from './constants';
 
@@ -39,7 +40,7 @@ class Backdrop extends Component {
 }
 
 Backdrop.propTypes = {
-  onPress: React.PropTypes.func.isRequired,
+  onPress: PropTypes.func.isRequired,
 };
 
 const styles = StyleSheet.create({

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { MenuOptions, MenuTrigger } from './index';
 import ContextMenu from './renderers/ContextMenu';
@@ -134,13 +135,13 @@ Menu.setDefaultRenderer = (renderer) => {
 }
 
 Menu.propTypes = {
-  name: React.PropTypes.string,
-  renderer: React.PropTypes.func,
-  onSelect: React.PropTypes.func,
-  onOpen: React.PropTypes.func,
-  onClose: React.PropTypes.func,
-  opened: React.PropTypes.bool,
-  onBackdropPress: React.PropTypes.func,
+  name: PropTypes.string,
+  renderer: PropTypes.func,
+  onSelect: PropTypes.func,
+  onOpen: PropTypes.func,
+  onClose: PropTypes.func,
+  opened: PropTypes.bool,
+  onBackdropPress: PropTypes.func,
 };
 
 Menu.defaultProps = {
@@ -152,6 +153,6 @@ Menu.defaultProps = {
 };
 
 Menu.contextTypes = {
-  menuRegistry: React.PropTypes.object,
-  menuActions: React.PropTypes.object,
+  menuRegistry: PropTypes.object,
+  menuActions: PropTypes.object,
 };

--- a/src/MenuContext.js
+++ b/src/MenuContext.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import makeMenuRegistry from './menuRegistry';
 import Backdrop from './Backdrop';
@@ -236,7 +237,7 @@ export default class MenuContext extends Component {
 }
 
 MenuContext.propTypes = {
-  customStyles: React.PropTypes.object,
+  customStyles: PropTypes.object,
 }
 
 MenuContext.defaultProps = {
@@ -244,6 +245,6 @@ MenuContext.defaultProps = {
 };
 
 MenuContext.childContextTypes = {
-  menuRegistry: React.PropTypes.object,
-  menuActions: React.PropTypes.object,
+  menuRegistry: PropTypes.object,
+  menuActions: PropTypes.object,
 };

--- a/src/MenuOption.js
+++ b/src/MenuOption.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View, StyleSheet, Text } from 'react-native';
 import { debug } from './logger';
 import { makeTouchable } from './helpers';
@@ -43,11 +44,11 @@ export default class MenuOption extends Component {
 }
 
 MenuOption.propTypes = {
-  disabled: React.PropTypes.bool,
-  onSelect: React.PropTypes.func,
-  text: React.PropTypes.string,
-  value: React.PropTypes.any,
-  customStyles: React.PropTypes.object,
+  disabled: PropTypes.bool,
+  onSelect: PropTypes.func,
+  text: PropTypes.string,
+  value: PropTypes.any,
+  customStyles: PropTypes.object,
 };
 
 MenuOption.defaultProps = {
@@ -56,7 +57,7 @@ MenuOption.defaultProps = {
 };
 
 MenuOption.contextTypes = {
-  menuActions: React.PropTypes.object,
+  menuActions: PropTypes.object,
 };
 
 const defaultStyles = StyleSheet.create({

--- a/src/MenuOptions.js
+++ b/src/MenuOptions.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { View } from 'react-native';
 
 const MenuOptions = ({ style, children, onSelect, customStyles }) => (

--- a/src/MenuTrigger.js
+++ b/src/MenuTrigger.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { View, Text } from 'react-native';
 import { debug } from './logger.js';
 import { makeTouchable } from './helpers';
@@ -33,10 +34,10 @@ export default class MenuTrigger extends Component {
 }
 
 MenuTrigger.propTypes = {
-  disabled: React.PropTypes.bool,
-  text: React.PropTypes.string,
-  onPress: React.PropTypes.func,
-  customStyles: React.PropTypes.object,
+  disabled: PropTypes.bool,
+  text: PropTypes.string,
+  onPress: PropTypes.func,
+  customStyles: PropTypes.object,
 };
 
 MenuTrigger.defaultProps = {
@@ -45,6 +46,6 @@ MenuTrigger.defaultProps = {
 };
 
 MenuTrigger.contextTypes = {
-  menuActions: React.PropTypes.object,
+  menuActions: PropTypes.object,
 };
 


### PR DESCRIPTION
I tried to use react 16 and I had some issue with this package. PropTypes was deprecated in 15.5 but it seems to have been removed in 16. https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html