### PR TITLE
MenuOption ability to disable Touchable wrapper

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -162,6 +162,7 @@ Wrapper component of menu option.
 |`value`|`Any`|Optional||Value of option|
 |`text`|`String`|Optional||Text to be rendered. When this prop is provided, option's children won't be rendered|
 |`disabled`|`Boolean`|Optional|`false`|Indicates if option can be pressed|
+|`disableTouchable`|`Boolean`|Optional|`false`|Disables Touchable wrapper (no on press effect and no onSelect execution)|
 |`customStyles`|`Object`|Optional||Object defining wrapper, touchable and text styles|
 
 ### Events

--- a/src/MenuOption.js
+++ b/src/MenuOption.js
@@ -62,6 +62,7 @@ MenuOption.propTypes = {
 
 MenuOption.defaultProps = {
   disabled: false,
+  disableTouchable: false,
   customStyles: {},
 };
 

--- a/src/MenuOption.js
+++ b/src/MenuOption.js
@@ -16,7 +16,7 @@ export default class MenuOption extends Component {
   }
 
   render() {
-    const { text, disabled, children, style, customStyles } = this.props;
+    const { text, disabled, disableTouchable, children, style, customStyles } = this.props;
     if (text && React.Children.count(children) > 0) {
       console.warn("MenuOption: Please don't use text property together with explicit children. Children are ignored.");
     }
@@ -28,23 +28,32 @@ export default class MenuOption extends Component {
         </View>
       );
     }
-    const { Touchable, defaultTouchableProps } = makeTouchable(customStyles.OptionTouchableComponent);
-    return (
-      <Touchable
-        onPress={() => this._onSelect()}
-        {...defaultTouchableProps}
-        {...customStyles.optionTouchable}
-      >
-        <View style={[defaultStyles.option, customStyles.optionWrapper, style]}>
-          {text ? <Text style={customStyles.optionText}>{text}</Text> : children}
-        </View>
-      </Touchable>
+    const rendered = (
+      <View style={[defaultStyles.option, customStyles.optionWrapper, style]}>
+        {text ? <Text style={customStyles.optionText}>{text}</Text> : children}
+      </View>
     );
+    if (disableTouchable) {
+      return rendered;
+    }
+    else {
+      const { Touchable, defaultTouchableProps } = makeTouchable(customStyles.OptionTouchableComponent);
+      return (
+        <Touchable
+          onPress={() => this._onSelect()}
+          {...defaultTouchableProps}
+          {...customStyles.optionTouchable}
+        >
+          {rendered}
+        </Touchable>
+      );
+    }
   }
 }
 
 MenuOption.propTypes = {
   disabled: PropTypes.bool,
+  disableTouchable: PropTypes.bool,
   onSelect: PropTypes.func,
   text: PropTypes.string,
   value: PropTypes.any,


### PR DESCRIPTION
Add the prop 'disableTouchable' prop to 'MenuOption'. If this props is 'true', the component will be rendered without Touchable wrapper. This is required, if you would not have a clickable popup-menu, but e.g. sliders for an option in the popup-menu.