### PR TITLE
Fix typo breaking MenuOptions style types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -88,7 +88,7 @@ declare module 'react-native-popup-menu' {
   interface MenuOptionsProps {
     optionsContainerStyle?: StyleProp<ViewStyle>;
     renderOptionsContainer?: Function;
-    customStyles?: MenuOptionCustomStyle;
+    customStyles?: MenuOptionsCustomStyle;
   }
 
   interface MenuOptionsCustomStyle extends MenuOptionCustomStyle {


### PR DESCRIPTION
Yey typescript! upgraded to new version and started using these types and found this typo