### PR TITLE
desktop platform added in 'makeTouchable`

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -31,6 +31,7 @@ export function makeTouchable(TouchableComponent) {
     ios: TouchableHighlight,
     web: TouchableHighlight,
     windows:TouchableHighlight,
+    desktop: TouchableHighlight,
   });
   let defaultTouchableProps = {};
   if (Touchable === TouchableHighlight) {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -29,9 +29,7 @@ export function makeTouchable(TouchableComponent) {
   const Touchable = TouchableComponent || Platform.select({
     android: TouchableNativeFeedback,
     ios: TouchableHighlight,
-    web: TouchableHighlight,
-    windows:TouchableHighlight,
-    desktop: TouchableHighlight,
+    default: TouchableHighlight,
   });
   let defaultTouchableProps = {};
   if (Touchable === TouchableHighlight) {


### PR DESCRIPTION
I tried to use the project with [react-native-desktop](https://github.com/status-im/react-native-desktop) and in order to do this `desktop` platform should be added to `makeTouchable`.
Do you mind adding it?

Thanks,
Volodymyr.