### PR TITLE
feat(MenuTrigger) adds triggerOnLongPress prop 

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -103,6 +103,7 @@ Menu can by opened by clicking on `<MenuTrigger />` or by calling context method
 |`children`|`Elements`|Optional||React elements to render as menu trigger. Exclusive with `text` property|
 |`text`|`String`|Optional||Text to be rendered. When this prop is provided, trigger's children won't be rendered|
 |`customStyles`|`Object`|Optional||Object defining wrapper, touchable and text styles|
+|`triggerOnLongPress`|`Boolean`|Optional|`false`|If `true`, menu will trigger onLongPress instead of onPress|
 
 ### Events
 | Event Name | Arguments | Notes |

--- a/src/MenuTrigger.js
+++ b/src/MenuTrigger.js
@@ -14,13 +14,14 @@ export class MenuTrigger extends Component {
   }
 
   render() {
-    const { disabled, onRef, text, children, style, customStyles, menuName, ...other } = this.props;
+    const { disabled, onRef, text, children, style, customStyles, menuName, triggerOnLongPress, ...other } = this.props;
     const onPress = () => !disabled && this._onPress();
     const { Touchable, defaultTouchableProps } = makeTouchable(customStyles.TriggerTouchableComponent);
     return (
       <View ref={onRef} collapsable={false} style={customStyles.triggerOuterWrapper}>
         <Touchable
-          onPress={onPress}
+          onPress={triggerOnLongPress ? null : onPress}
+          onLongPress={triggerOnLongPress ? onPress : null}
           {...defaultTouchableProps}
           {...customStyles.triggerTouchable}
         >
@@ -39,6 +40,7 @@ MenuTrigger.propTypes = {
   text: PropTypes.string,
   onPress: PropTypes.func,
   customStyles: PropTypes.object,
+  triggerOnLongPress: PropTypes.bool,
 };
 
 MenuTrigger.defaultProps = {


### PR DESCRIPTION
This PR adds a 'triggerOnLongPress' prop that will make the menu activate onLongPress instead of onPress.

