### PR TITLE
Access both onPress and onLongPress

### DIFF
--- a/src/MenuTrigger.js
+++ b/src/MenuTrigger.js
@@ -14,14 +14,14 @@ export class MenuTrigger extends Component {
   }
 
   render() {
-    const { disabled, onRef, text, children, style, customStyles, menuName, triggerOnLongPress, ...other } = this.props;
-    const onPress = () => !disabled && this._onPress();
+    const { disabled, onRef, text, children, style, customStyles, menuName, triggerOnLongPress, onSelect, ...other } = this.props;
+    const openMenu = () => !disabled && this._onPress();
     const { Touchable, defaultTouchableProps } = makeTouchable(customStyles.TriggerTouchableComponent);
     return (
       <View ref={onRef} collapsable={false} style={customStyles.triggerOuterWrapper}>
         <Touchable
-          onPress={triggerOnLongPress ? null : onPress}
-          onLongPress={triggerOnLongPress ? onPress : null}
+          onPress={triggerOnLongPress ? openMenu : onSelect}
+          onLongPress={triggerOnLongPress ? onSelect : openMenu}
           {...defaultTouchableProps}
           {...customStyles.triggerTouchable}
         >
@@ -41,6 +41,7 @@ MenuTrigger.propTypes = {
   onPress: PropTypes.func,
   customStyles: PropTypes.object,
   triggerOnLongPress: PropTypes.bool,
+  onSelect: PropTypes.func,
 };
 
 MenuTrigger.defaultProps = {


### PR DESCRIPTION
So in my case I have a card. When I press it (onPress) I need to activate something (send something to server), and when I'm pressing for some seconds (onLongPress) I want to open the menu. I couldn't do it without changing the code on MenuTrigger.js. If you find this useful you can add it. If somehow I can achieve the same thing without changing the repo code I would be glad to know how.