### PR TITLE
(MenuTrigger) Add type decl for triggerOnLongPress

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -76,8 +76,10 @@ declare module "react-native-popup-menu" {
       TriggerTouchableComponent?: Function;
       triggerTouchable?: {};
     };
+    triggerOnLongPress?: boolean;
 
     onPress?(): void;
+    onAlternativeAction? (): void;
   }
 
   export const MenuTrigger: React.ComponentClass<MenuTriggerProps>;


### PR DESCRIPTION
Add missing type declaration of props triggerOnLongPress and onAlternativeAction under MenuTriggerProps.