### PR TITLE
fix: adding missing testID to MenuTrigger and MenuOption props

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -82,6 +82,7 @@ declare module "react-native-popup-menu" {
       TriggerTouchableComponent?: Function;
       triggerTouchable?: {};
     };
+    testID?: string;
     triggerOnLongPress?: boolean;
 
     onPress?(): void;
@@ -98,6 +99,7 @@ declare module "react-native-popup-menu" {
     optionsContainerStyle?: StyleProp<ViewStyle>;
     renderOptionsContainer?: Function;
     customStyles?: MenuOptionsCustomStyle;
+    testID?: string;
   }
 
   interface MenuOptionsCustomStyle extends MenuOptionCustomStyle {


### PR DESCRIPTION
Following #197  and #198 It looks like adding testID to type definitions is necessary.