### PR TITLE
Update definitions for MenuOptionCustomStyle interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -129,6 +129,7 @@ declare module "react-native-popup-menu" {
     optionWrapper?: StyleProp<ViewStyle>;
     optionText?: StyleProp<TextStyle>;
     optionTouchable?: {};
+    OptionTouchableComponent?: Function;
   }
 
   export const MenuOption: React.ComponentClass<MenuOptionProps>;


### PR DESCRIPTION
`MenuOptionCustomStyle` and `MenuOptionsCustomStyle` interfaces do not have `OptionTouchableComponent` property according to the docs: https://github.com/instea/react-native-popup-menu/blob/master/doc/api.md#custom-styles-2